### PR TITLE
Rewrite to support Hue Bridge Pro API v2 and Homebridge v2.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
 
 const https = require('https');
 
+// The Hue Bridge uses a self-signed TLS certificate. We create a dedicated
+// agent that skips verification, used only for requests in this plugin.
 const hueAgent = new https.Agent({ rejectUnauthorized: false });
 
 module.exports = (api) => {
@@ -19,12 +21,8 @@ class HueSensorsAccessory {
         this.Service        = api.hap.Service;
         this.Characteristic = api.hap.Characteristic;
 
-        this.filter  = config['filter'];
-        this.bridges = config['bridges'];
-
-        // DEBUG: log what we received from config at startup
-        this.log(`DEBUG filter: ${JSON.stringify(this.filter)}`);
-        this.log(`DEBUG bridges: ${JSON.stringify(this.bridges.map(b => ({ IP: b.IP, keyLength: b.username?.length })))}`);
+        this.filter  = config['filter'];   // e.g. ["Living Room Sensor"]
+        this.bridges = config['bridges'];  // e.g. [{IP, username}]
     }
 
 
@@ -51,8 +49,6 @@ class HueSensorsAccessory {
                 let raw = '';
                 res.on('data', chunk => raw += chunk);
                 res.on('end', () => {
-                    // DEBUG: log raw HTTP status and first 200 chars of response
-                    this.log(`DEBUG ${method} ${path} → HTTP ${res.statusCode} — ${raw.substring(0, 200)}`);
                     try {
                         const parsed = JSON.parse(raw);
                         if (parsed.errors && parsed.errors.length > 0) {
@@ -78,24 +74,14 @@ class HueSensorsAccessory {
             this.hueRequest(bridge, 'GET', '/resource/motion'),
         ]);
 
-        // DEBUG: log counts and a sample of device names
-        this.log(`DEBUG devices returned: ${devices.length}`);
-        this.log(`DEBUG motions returned: ${motions.length}`);
-
         const deviceNames = {};
         for (const device of devices) {
             deviceNames[device.id] = device.metadata?.name;
         }
 
-        // DEBUG: log only the sensor-related devices
-        const sensorEntries = Object.entries(deviceNames).filter(([, n]) => n && n.includes('Sensor'));
-        this.log(`DEBUG sensor devices: ${JSON.stringify(sensorEntries)}`);
-
         const matched = [];
         for (const motion of motions) {
             const ownerName = deviceNames[motion.owner?.rid];
-            // DEBUG: log each motion sensor lookup result
-            this.log(`DEBUG motion ${motion.id}: owner rid=${motion.owner?.rid} → name="${ownerName}" — filter match=${this.filter.includes(ownerName)}`);
             if (ownerName && this.filter.includes(ownerName)) {
                 matched.push({
                     bridge,
@@ -105,8 +91,6 @@ class HueSensorsAccessory {
                 });
             }
         }
-
-        this.log(`DEBUG matched sensors: ${matched.length}`);
         return matched;
     }
 

--- a/index.js
+++ b/index.js
@@ -64,8 +64,17 @@ class HueSensorsAccessory {
                         if (this.filter.indexOf(sensor.name) > -1) {
                             if (sensor.type === 'ZLLPresence') {
                                 sensor.config.on = state;
-                                client.sensors.save(sensor);
-                                this.log(`Sensor [${sensor.id}]: ${sensor.name} On: ${sensor.config.on}`);
+                                // FIX 3: .catch() added to sensors.save() — without this,
+                                // a rejection from the Hue bridge (e.g. Hue Bridge 2
+                                // blocking v1 API config writes) is an unhandled rejection
+                                // that crashes the child bridge process.
+                                client.sensors.save(sensor)
+                                    .then(() => {
+                                        this.log(`Sensor [${sensor.id}]: ${sensor.name} On: ${sensor.config.on}`);
+                                    })
+                                    .catch(error => {
+                                        this.log.error(`Failed to save sensor [${sensor.id}] ${sensor.name}: ${error.message}`);
+                                    });
                             }
                         }
                     }

--- a/index.js
+++ b/index.js
@@ -2,8 +2,6 @@
 
 const https = require('https');
 
-// The Hue Bridge uses a self-signed TLS certificate. We create a dedicated
-// agent that skips verification, used only for requests in this plugin.
 const hueAgent = new https.Agent({ rejectUnauthorized: false });
 
 module.exports = (api) => {
@@ -21,8 +19,12 @@ class HueSensorsAccessory {
         this.Service        = api.hap.Service;
         this.Characteristic = api.hap.Characteristic;
 
-        this.filter  = config['filter'];   // e.g. ["Living Room Sensor"]
-        this.bridges = config['bridges'];  // e.g. [{IP, username}]
+        this.filter  = config['filter'];
+        this.bridges = config['bridges'];
+
+        // DEBUG: log what we received from config at startup
+        this.log(`DEBUG filter: ${JSON.stringify(this.filter)}`);
+        this.log(`DEBUG bridges: ${JSON.stringify(this.bridges.map(b => ({ IP: b.IP, keyLength: b.username?.length })))}`);
     }
 
 
@@ -49,6 +51,8 @@ class HueSensorsAccessory {
                 let raw = '';
                 res.on('data', chunk => raw += chunk);
                 res.on('end', () => {
+                    // DEBUG: log raw HTTP status and first 200 chars of response
+                    this.log(`DEBUG ${method} ${path} → HTTP ${res.statusCode} — ${raw.substring(0, 200)}`);
                     try {
                         const parsed = JSON.parse(raw);
                         if (parsed.errors && parsed.errors.length > 0) {
@@ -74,14 +78,24 @@ class HueSensorsAccessory {
             this.hueRequest(bridge, 'GET', '/resource/motion'),
         ]);
 
+        // DEBUG: log counts and a sample of device names
+        this.log(`DEBUG devices returned: ${devices.length}`);
+        this.log(`DEBUG motions returned: ${motions.length}`);
+
         const deviceNames = {};
         for (const device of devices) {
             deviceNames[device.id] = device.metadata?.name;
         }
 
+        // DEBUG: log only the sensor-related devices
+        const sensorEntries = Object.entries(deviceNames).filter(([, n]) => n && n.includes('Sensor'));
+        this.log(`DEBUG sensor devices: ${JSON.stringify(sensorEntries)}`);
+
         const matched = [];
         for (const motion of motions) {
             const ownerName = deviceNames[motion.owner?.rid];
+            // DEBUG: log each motion sensor lookup result
+            this.log(`DEBUG motion ${motion.id}: owner rid=${motion.owner?.rid} → name="${ownerName}" — filter match=${this.filter.includes(ownerName)}`);
             if (ownerName && this.filter.includes(ownerName)) {
                 matched.push({
                     bridge,
@@ -91,6 +105,8 @@ class HueSensorsAccessory {
                 });
             }
         }
+
+        this.log(`DEBUG matched sensors: ${matched.length}`);
         return matched;
     }
 
@@ -115,10 +131,6 @@ class HueSensorsAccessory {
 
         const switchService = new Service.Switch(this.config.name || 'Hue Sensors');
 
-        // Use the promise-based onGet/onSet handlers (Homebridge 1.3+).
-        // The old callback-based .on('get') / .on('set') pattern causes HomeKit
-        // to sometimes skip calling 'set' if it believes the state hasn't changed,
-        // which is why toggling the switch had no effect.
         switchService.getCharacteristic(Characteristic.On)
             .onGet(async () => {
                 const sensors = await this.getAllFilteredMotionSensors();

--- a/index.js
+++ b/index.js
@@ -1,5 +1,14 @@
 'use strict';
 
+// FIX 1: The Hue bridge uses a self-signed TLS certificate. Newer Node.js
+// versions reject these by default, causing "unable to verify the first
+// certificate". This tells Node.js to allow them for requests made by this
+// plugin. Scoped here at module load rather than globally on the process.
+const https = require('https');
+const httpsAgent = new https.Agent({ rejectUnauthorized: false });
+// huejay uses axios under the hood; patch the default agent it will pick up.
+https.globalAgent = httpsAgent;
+
 const huejay = require('huejay');
 
 /**
@@ -11,6 +20,8 @@ const huejay = require('huejay');
  *  - Service and Characteristic are obtained from api.hap inside the constructor
  *  - Constructor accepts (log, config, api) — the third arg is new
  *  - Converted to ES6 class for clarity (optional but recommended)
+ *  - FIX 1: TLS certificate verification disabled for self-signed Hue bridge cert
+ *  - FIX 2: Promise.all() now has a .catch() to prevent UnhandledPromiseRejection
  */
 module.exports = (api) => {
     api.registerAccessory('HueSensors', HueSensorsAccessory);
@@ -94,9 +105,17 @@ class HueSensorsAccessory {
             }));
         }
 
-        Promise.all(promises).then(values => {
-            callback(values.indexOf(false) === -1);
-        });
+        // FIX 2: .catch() added here to handle rejections from any individual
+        // bridge promise (e.g. SSL errors, network timeouts). Without this,
+        // Node.js v15+ throws an UnhandledPromiseRejection and crashes.
+        Promise.all(promises)
+            .then(values => {
+                callback(values.indexOf(false) === -1);
+            })
+            .catch(error => {
+                this.log.error('Error checking bridges: ' + error);
+                callback(false);
+            });
     }
 
 

--- a/index.js
+++ b/index.js
@@ -1,161 +1,147 @@
 'use strict';
-var Service, Characteristic;
-let huejay = require('huejay');
+
+const huejay = require('huejay');
+
+/**
+ * Homebridge v1.6+ / v2.x compatible plugin registration.
+ *
+ * Key changes from the original (2017) code:
+ *  - module.exports now receives the `api` object, not the legacy `homebridge` shim
+ *  - registerAccessory() takes 2 args (accessory name + class), not 3
+ *  - Service and Characteristic are obtained from api.hap inside the constructor
+ *  - Constructor accepts (log, config, api) — the third arg is new
+ *  - Converted to ES6 class for clarity (optional but recommended)
+ */
+module.exports = (api) => {
+    api.registerAccessory('HueSensors', HueSensorsAccessory);
+};
 
 
-module.exports = function (homebridge) {
-    Service = homebridge.hap.Service;
-    Characteristic = homebridge.hap.Characteristic;
-    homebridge.registerAccessory("homebridge-huesensors", "HueSensors", HueSensorsAccessory);
-}
+class HueSensorsAccessory {
 
+    constructor(log, config, api) {
+        this.log    = log;
+        this.config = config;
+        this.api    = api;
 
-function HueSensorsAccessory(log, config) {
-    this.log = log;
-    this.filter = config["filter"];
-    this.clients = [];
-    for (let bridge of config["bridges"]) {
+        // In the new API, Service and Characteristic live on api.hap
+        this.Service        = api.hap.Service;
+        this.Characteristic = api.hap.Characteristic;
 
-        var newBridge = new huejay.Client({
-            host: bridge.IP,
-            port: 80,               // Optional
-            username: bridge.username,
-            timeout: 15000,            // Optional, timeout in milliseconds (15000 is the default)
-        });
+        this.filter  = config['filter'];
+        this.clients = [];
 
-        this.clients.push(newBridge);
-
+        for (const bridge of config['bridges']) {
+            const newBridge = new huejay.Client({
+                host:     bridge.IP,
+                port:     80,
+                username: bridge.username,
+                timeout:  15000,
+            });
+            this.clients.push(newBridge);
+        }
     }
 
-}
 
-HueSensorsAccessory.prototype = {
+    // ─── Private helpers ────────────────────────────────────────────────────────
 
-    setState: function (state) {
-        for (let client of this.clients) {
-
+    setState(state) {
+        for (const client of this.clients) {
             client.sensors.getAll()
                 .then(sensors => {
-                    for (let sensor of sensors) {
-
-                        //only check for sensors specified in the config
+                    for (const sensor of sensors) {
                         if (this.filter.indexOf(sensor.name) > -1) {
-
-                            if (sensor.type == "ZLLPresence") {
-
+                            if (sensor.type === 'ZLLPresence') {
                                 sensor.config.on = state;
                                 client.sensors.save(sensor);
-
                                 this.log(`Sensor [${sensor.id}]: ${sensor.name} On: ${sensor.config.on}`);
-
                             }
                         }
                     }
                 })
                 .catch(error => {
-                    console.log(error.stack);
+                    this.log.error(error.stack);
                 });
         }
-    },
+    }
 
-    checkBridges: function (callback) {
-        
-        var promises = [];
-        
-        for (let client of this.clients) {
+    checkBridges(callback) {
+        const promises = [];
 
+        for (const client of this.clients) {
             promises.push(new Promise((resolve, reject) => {
-                
-                var sensorsON = true;
+                let sensorsON = true;
+
                 client.sensors.getAll()
                     .then(sensors => {
-                        for (let sensor of sensors) {
-
-                            //only check for sensors specified in the config
+                        for (const sensor of sensors) {
                             if (this.filter.indexOf(sensor.name) > -1) {
-
-                                if (sensor.type == "ZLLPresence") {
-
+                                if (sensor.type === 'ZLLPresence') {
                                     this.log(`Sensor [${sensor.id}]: ${sensor.name} On: ${sensor.config.on}`);
-
-                                    //at least one sensor is off, so return off
-                                    if (sensor.config.on == false) {
+                                    if (sensor.config.on === false) {
                                         sensorsON = false;
-                                        this.log("A sensor is OFF: " + sensor.name);
+                                        this.log('A sensor is OFF: ' + sensor.name);
                                     }
-
                                 }
                             }
                         }
-
-                        //this.log("finished bridge: " + client.username);
                         resolve(sensorsON);
-
                     })
                     .catch(error => {
-                        console.log(error.stack);
+                        this.log.error(error.stack);
                         reject(error.stack);
                     });
-                
             }));
-
         }
 
         Promise.all(promises).then(values => {
+            callback(values.indexOf(false) === -1);
+        });
+    }
 
-            if (values.indexOf(false) > -1) {
-                callback(false);
-            } else {
-                callback(true);
-            }
 
-        })
+    // ─── Characteristic handlers ─────────────────────────────────────────────
 
-    },
-
-    getPowerState: function (callback) {
-        this.checkBridges(function (retval) {
+    getPowerState(callback) {
+        this.checkBridges(retval => {
             if (retval) {
-                console.log("all on");
+                this.log('All sensors on');
                 callback(null, 1);
             } else {
-                console.log("at least one off");
+                this.log('At least one sensor off');
                 callback(null, 0);
             }
         });
-    },
+    }
 
-    setPowerState: function (powerOn, callback) {
-        if (powerOn) {
-            //turn on
-            this.setState(true);
-            callback();
-        } else {
-            //turn off
-            this.setState(false);
-            callback();
-        }
-    },
+    setPowerState(powerOn, callback) {
+        this.setState(powerOn);
+        callback();
+    }
+
+    identify(callback) {
+        this.log('Identify requested!');
+        callback();
+    }
 
 
-    identify: function (callback) {
-        this.log("Identify requested!");
-        callback(); // success
-    },
+    // ─── Homebridge lifecycle ────────────────────────────────────────────────
 
-    getServices: function () {
-        var informationService = new Service.AccessoryInformation();
+    getServices() {
+        const { Service, Characteristic } = this;
+
+        const informationService = new Service.AccessoryInformation();
         informationService
-            .setCharacteristic(Characteristic.Manufacturer, "HueSensors Manufacturer")
-            .setCharacteristic(Characteristic.Model, "HueSensors Model")
-            .setCharacteristic(Characteristic.SerialNumber, "HueSensors Serial Number");
+            .setCharacteristic(Characteristic.Manufacturer, 'HueSensors Manufacturer')
+            .setCharacteristic(Characteristic.Model,        'HueSensors Model')
+            .setCharacteristic(Characteristic.SerialNumber, 'HueSensors Serial Number');
 
-        var switchService = new Service.Switch(this.name);
+        const switchService = new Service.Switch(this.config.name || 'Hue Sensors');
         switchService
             .getCharacteristic(Characteristic.On)
             .on('get', this.getPowerState.bind(this))
             .on('set', this.setPowerState.bind(this));
 
-        return [switchService];
+        return [informationService, switchService];
     }
-};
+}

--- a/index.js
+++ b/index.js
@@ -1,28 +1,11 @@
 'use strict';
 
-// FIX 1: The Hue bridge uses a self-signed TLS certificate. Newer Node.js
-// versions reject these by default, causing "unable to verify the first
-// certificate". This tells Node.js to allow them for requests made by this
-// plugin. Scoped here at module load rather than globally on the process.
 const https = require('https');
-const httpsAgent = new https.Agent({ rejectUnauthorized: false });
-// huejay uses axios under the hood; patch the default agent it will pick up.
-https.globalAgent = httpsAgent;
 
-const huejay = require('huejay');
+// The Hue Bridge uses a self-signed TLS certificate. We create a dedicated
+// agent that skips verification, used only for requests in this plugin.
+const hueAgent = new https.Agent({ rejectUnauthorized: false });
 
-/**
- * Homebridge v1.6+ / v2.x compatible plugin registration.
- *
- * Key changes from the original (2017) code:
- *  - module.exports now receives the `api` object, not the legacy `homebridge` shim
- *  - registerAccessory() takes 2 args (accessory name + class), not 3
- *  - Service and Characteristic are obtained from api.hap inside the constructor
- *  - Constructor accepts (log, config, api) — the third arg is new
- *  - Converted to ES6 class for clarity (optional but recommended)
- *  - FIX 1: TLS certificate verification disabled for self-signed Hue bridge cert
- *  - FIX 2: Promise.all() now has a .catch() to prevent UnhandledPromiseRejection
- */
 module.exports = (api) => {
     api.registerAccessory('HueSensors', HueSensorsAccessory);
 };
@@ -35,121 +18,87 @@ class HueSensorsAccessory {
         this.config = config;
         this.api    = api;
 
-        // In the new API, Service and Characteristic live on api.hap
         this.Service        = api.hap.Service;
         this.Characteristic = api.hap.Characteristic;
 
-        this.filter  = config['filter'];
-        this.clients = [];
-
-        for (const bridge of config['bridges']) {
-            const newBridge = new huejay.Client({
-                host:     bridge.IP,
-                port:     80,
-                username: bridge.username,
-                timeout:  15000,
-            });
-            this.clients.push(newBridge);
-        }
+        this.filter  = config['filter'];   // e.g. ["Living Room Sensor"]
+        this.bridges = config['bridges'];  // e.g. [{IP, username}]
     }
 
 
-    // ─── Private helpers ────────────────────────────────────────────────────────
+    // ─── Hue API v2 helpers ──────────────────────────────────────────────────
 
-    setState(state) {
-        for (const client of this.clients) {
-            client.sensors.getAll()
-                .then(sensors => {
-                    for (const sensor of sensors) {
-                        if (this.filter.indexOf(sensor.name) > -1) {
-                            if (sensor.type === 'ZLLPresence') {
-                                sensor.config.on = state;
-                                // FIX 3: .catch() added to sensors.save() — without this,
-                                // a rejection from the Hue bridge (e.g. Hue Bridge 2
-                                // blocking v1 API config writes) is an unhandled rejection
-                                // that crashes the child bridge process.
-                                client.sensors.save(sensor)
-                                    .then(() => {
-                                        this.log(`Sensor [${sensor.id}]: ${sensor.name} On: ${sensor.config.on}`);
-                                    })
-                                    .catch(error => {
-                                        this.log.error(`Failed to save sensor [${sensor.id}] ${sensor.name}: ${error.message}`);
-                                    });
-                            }
+    hueRequest(bridge, method, path, body = null) {
+        return new Promise((resolve, reject) => {
+            const bodyStr = body ? JSON.stringify(body) : null;
+
+            const options = {
+                hostname: bridge.IP,
+                port:     443,
+                path:     `/clip/v2${path}`,
+                method:   method,
+                headers:  {
+                    'hue-application-key': bridge.username,
+                    'Content-Type':        'application/json',
+                    ...(bodyStr ? { 'Content-Length': Buffer.byteLength(bodyStr) } : {}),
+                },
+                agent: hueAgent,
+            };
+
+            const req = https.request(options, (res) => {
+                let raw = '';
+                res.on('data', chunk => raw += chunk);
+                res.on('end', () => {
+                    try {
+                        const parsed = JSON.parse(raw);
+                        if (parsed.errors && parsed.errors.length > 0) {
+                            reject(new Error(parsed.errors[0].description));
+                        } else {
+                            resolve(parsed.data || []);
                         }
+                    } catch (e) {
+                        reject(new Error(`Failed to parse bridge response: ${raw}`));
                     }
-                })
-                .catch(error => {
-                    this.log.error(error.stack);
                 });
-        }
-    }
-
-    checkBridges(callback) {
-        const promises = [];
-
-        for (const client of this.clients) {
-            promises.push(new Promise((resolve, reject) => {
-                let sensorsON = true;
-
-                client.sensors.getAll()
-                    .then(sensors => {
-                        for (const sensor of sensors) {
-                            if (this.filter.indexOf(sensor.name) > -1) {
-                                if (sensor.type === 'ZLLPresence') {
-                                    this.log(`Sensor [${sensor.id}]: ${sensor.name} On: ${sensor.config.on}`);
-                                    if (sensor.config.on === false) {
-                                        sensorsON = false;
-                                        this.log('A sensor is OFF: ' + sensor.name);
-                                    }
-                                }
-                            }
-                        }
-                        resolve(sensorsON);
-                    })
-                    .catch(error => {
-                        this.log.error(error.stack);
-                        reject(error.stack);
-                    });
-            }));
-        }
-
-        // FIX 2: .catch() added here to handle rejections from any individual
-        // bridge promise (e.g. SSL errors, network timeouts). Without this,
-        // Node.js v15+ throws an UnhandledPromiseRejection and crashes.
-        Promise.all(promises)
-            .then(values => {
-                callback(values.indexOf(false) === -1);
-            })
-            .catch(error => {
-                this.log.error('Error checking bridges: ' + error);
-                callback(false);
             });
-    }
 
-
-    // ─── Characteristic handlers ─────────────────────────────────────────────
-
-    getPowerState(callback) {
-        this.checkBridges(retval => {
-            if (retval) {
-                this.log('All sensors on');
-                callback(null, 1);
-            } else {
-                this.log('At least one sensor off');
-                callback(null, 0);
-            }
+            req.on('error', reject);
+            if (bodyStr) req.write(bodyStr);
+            req.end();
         });
     }
 
-    setPowerState(powerOn, callback) {
-        this.setState(powerOn);
-        callback();
+    async getFilteredMotionSensors(bridge) {
+        const [devices, motions] = await Promise.all([
+            this.hueRequest(bridge, 'GET', '/resource/device'),
+            this.hueRequest(bridge, 'GET', '/resource/motion'),
+        ]);
+
+        const deviceNames = {};
+        for (const device of devices) {
+            deviceNames[device.id] = device.metadata?.name;
+        }
+
+        const matched = [];
+        for (const motion of motions) {
+            const ownerName = deviceNames[motion.owner?.rid];
+            if (ownerName && this.filter.includes(ownerName)) {
+                matched.push({
+                    bridge,
+                    motionId: motion.id,
+                    name:     ownerName,
+                    enabled:  motion.enabled,
+                });
+            }
+        }
+        return matched;
     }
 
-    identify(callback) {
-        this.log('Identify requested!');
-        callback();
+    async getAllFilteredMotionSensors() {
+        const results = await Promise.all(
+            this.bridges.map(bridge => this.getFilteredMotionSensors(bridge))
+        );
+        return results.flat();
     }
 
 
@@ -160,15 +109,53 @@ class HueSensorsAccessory {
 
         const informationService = new Service.AccessoryInformation();
         informationService
-            .setCharacteristic(Characteristic.Manufacturer, 'HueSensors Manufacturer')
-            .setCharacteristic(Characteristic.Model,        'HueSensors Model')
-            .setCharacteristic(Characteristic.SerialNumber, 'HueSensors Serial Number');
+            .setCharacteristic(Characteristic.Manufacturer, 'Signify')
+            .setCharacteristic(Characteristic.Model,        'Hue Motion Sensor')
+            .setCharacteristic(Characteristic.SerialNumber, 'homebridge-huesensors');
 
         const switchService = new Service.Switch(this.config.name || 'Hue Sensors');
-        switchService
-            .getCharacteristic(Characteristic.On)
-            .on('get', this.getPowerState.bind(this))
-            .on('set', this.setPowerState.bind(this));
+
+        // Use the promise-based onGet/onSet handlers (Homebridge 1.3+).
+        // The old callback-based .on('get') / .on('set') pattern causes HomeKit
+        // to sometimes skip calling 'set' if it believes the state hasn't changed,
+        // which is why toggling the switch had no effect.
+        switchService.getCharacteristic(Characteristic.On)
+            .onGet(async () => {
+                const sensors = await this.getAllFilteredMotionSensors();
+                if (sensors.length === 0) {
+                    this.log.warn('No matching sensors found — check filter names match the Hue app exactly');
+                    return false;
+                }
+                const allOn = sensors.every(s => s.enabled);
+                for (const sensor of sensors) {
+                    this.log(`Sensor "${sensor.name}": enabled=${sensor.enabled}`);
+                }
+                return allOn;
+            })
+            .onSet(async (value) => {
+                this.log(`Setting all filtered sensors to enabled=${value}`);
+                const sensors = await this.getAllFilteredMotionSensors();
+                if (sensors.length === 0) {
+                    this.log.warn('No matching sensors found — nothing to set');
+                    return;
+                }
+                await Promise.all(
+                    sensors.map(sensor =>
+                        this.hueRequest(
+                            sensor.bridge,
+                            'PUT',
+                            `/resource/motion/${sensor.motionId}`,
+                            { enabled: Boolean(value) }
+                        )
+                        .then(() => {
+                            this.log(`Sensor "${sensor.name}": set enabled=${Boolean(value)}`);
+                        })
+                        .catch(error => {
+                            this.log.error(`Failed to update "${sensor.name}": ${error.message}`);
+                        })
+                    )
+                );
+            });
 
         return [informationService, switchService];
     }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "homebridge-huesensors",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "HueSensors for homebridge",
+  "main": "index.js",
   "keywords": [
     "homebridge-plugin"
   ],
   "engines": {
-    "node": ">=0.12.0",
-    "homebridge": ">=0.2.0"
+    "node": "^18.20.4 || ^20.15.1 || ^22.0.0",
+    "homebridge": "^1.6.0 || ^2.0.0"
   },
   "author": {
     "name": "steedferns"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-huesensors",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "HueSensors for homebridge",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Summary: Full rewrite to support Hue Bridge Pro API v2 and Homebridge v2.
The original plugin used huejay (unmaintained) against the v1 API, which no longer works with Hue Bridge Pro. This rewrites the plugin using Node's built-in https module against CLIP v2 (/clip/v2/resource/device and /clip/v2/resource/motion).
Changes:

Drops huejay dependency entirely (no external dependencies)
Uses Hue API v2 — requires an API key generated with generateclientkey: true
Fixes Homebridge v2 compatibility: updated registerAccessory call, constructor signature (log, config, api), and switched to onGet/onSet async handlers
Adds rejectUnauthorized: false for the Hue Bridge's self-signed TLS certificate
Filter names must match Hue app device names exactly (e.g. "Hallway Sensor" not "zHueHallwaySensor")

Tested on: Homebridge v1.11.4, Hue Bridge Pro, Node v22, Raspberry Pi